### PR TITLE
Changes to support mio 0.5 (TcpSocket dependency removed, etc)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["websocket", "mio", "event-driven", "io", "web"]
 license = "MIT"
 
 [dependencies]
-mio = "*"
+mio = { git = "https://github.com/carllerche/mio" }
 log = "*"
 httparse = "*"
 sha1 = "*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -360,12 +360,11 @@ impl<F> WebSocket<F>
     /// Create a new WebSocket using the given Factory to create handlers.
     pub fn new(mut factory: F) -> Result<WebSocket<F>> {
         let max = factory.settings().max_connections;
+        let mut config = EventLoopConfig::new();
+        config.notify_capacity(max + 1000);
         WebSocket::with_config(
             factory,
-            EventLoopConfig {
-                notify_capacity: max + 1000,
-                .. EventLoopConfig::default()
-            },
+            config,
         )
     }
 


### PR DESCRIPTION
I've tried to move lib to **mio-0.5** (in Windows, because last mio supports that OS). Look at my changes, please. The main trouble is TcpSocket has hidden inside mio and can't be used.
In most cases difference was resolved, but I don't now how to fix this code right:

io.rs (lines 197-207)
```rust
if events.is_error() {
    trace!("Encountered error on tcp stream.");
    /* TODO: Fix it! TcpSocket hidden in mio and can't be used. take_socket_error was removed too.
    if let Err(err) = self.connections[token].socket().take_socket_error() {
        trace!("Error was {}", err);
        self.connections[token].error(Error::from(err));
    }
    */
    trace!("Dropping connection {:?}", token);
    self.connections.remove(token);
} else if events.is_hup() {
```
Method `take_socket_error()` not available now. Do you have ideas how can I fix it without break this routine and help to improve your library?