### PR TITLE
Fixed named argument in Factory::connection_made

### DIFF
--- a/src/factory.rs
+++ b/src/factory.rs
@@ -6,7 +6,7 @@ pub trait Factory {
     type Handler: Handler;
 
     /// Called when a TCP connection is made.
-    fn connection_made(&mut self, Sender) -> Self::Handler;
+    fn connection_made(&mut self, _: Sender) -> Self::Handler;
 
     /// Called when the WebSocket is shutting down.
     #[inline]


### PR DESCRIPTION
Avoids a compiler error when copying the function signature from the docs.