### PR TITLE
chore: Migrate to mio 0.5.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ version = "0.4.6"
 [dependencies]
 httparse = "1.1.1"
 log = "0.3.5"
-mio = "0.5.0"
+mio = "0.5.1"
 rand = "0.3.14"
 sha1 = "0.1.1"
 url = "0.5.7"


### PR DESCRIPTION
I have a project which depends on ws-rs and which I need to compile on ARM. The bump to mio 0.5.1 allows that.