### PR TITLE
impl From<Vec<u8>> for Message

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -122,6 +122,13 @@ impl<'b> From<&'b [u8]> for Message {
     }
 }
 
+impl From<Vec<u8>> for Message {
+
+    fn from(data: Vec<u8>) -> Message {
+        Message::binary(data)
+    }
+}
+
 impl fmt::Display for Message {
     fn fmt(&self, f: &mut fmt::Formatter) -> StdResult<(), fmt::Error> {
         if let Ok(string) = self.as_text() {
@@ -149,7 +156,16 @@ mod test {
     #[test]
     fn binary_convert() {
         let bin = [6u8, 7, 8, 9, 10, 241];
-        let msg = Message::from(&bin[..]);
+        let msg = Message::from(&bin);
+        assert!(msg.is_binary());
+        assert!(msg.into_text().is_err());
+    }
+
+
+    #[test]
+    fn binary_convert_vec() {
+        let bin = vec![6u8, 7, 8, 9, 10, 241];
+        let msg = Message::from(bin);
         assert!(msg.is_binary());
         assert!(msg.into_text().is_err());
     }


### PR DESCRIPTION
So you can pass a `Vec<u8>` to `Sender::send` directly and have it converted to `Message` without extra heap allocation.

This also makes binaries consistent with strings, which already implement `From` for `String` and `&str`.

Bit of a bummer: I weren't able to run tests, either on stable or nightly:

```
    Updating git repository `https://github.com/carllerche/mio.git`
    Updating registry `https://github.com/rust-lang/crates.io-index`
error: no matching package named `mio` found (required by `ws`)
location searched: https://github.com/carllerche/mio.git
version required: *
```