### PR TITLE
Remove deprecated MIO stuff

### DIFF
--- a/src/communication.rs
+++ b/src/communication.rs
@@ -10,7 +10,7 @@ use result::{Result, Error};
 use protocol::CloseCode;
 use io::ALL;
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub enum Signal {
     Message(message::Message),
     Close(CloseCode, Cow<'static, str>),
@@ -25,7 +25,7 @@ pub enum Signal {
     Cancel(mio::timer::Timeout),
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Command {
     token: Token,
     signal: Signal,
@@ -43,17 +43,17 @@ impl Command {
 
 /// A representation of the output of the WebSocket connection. Use this to send messages to the
 /// other endpoint.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Sender {
     token: Token,
-    channel: mio::deprecated::Sender<Command>,
+    channel: mio::channel::SyncSender<Command>,
 }
 
 impl Sender {
 
     #[doc(hidden)]
     #[inline]
-    pub fn new(token: Token, channel: mio::deprecated::Sender<Command>) -> Sender {
+    pub fn new(token: Token, channel: mio::channel::SyncSender<Command>) -> Sender {
         Sender {
             token: token,
             channel: channel,

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -126,13 +126,6 @@ mod test {
     use handler::Handler;
     use result::Result;
 
-    struct S;
-
-    impl mio::deprecated::Handler for S {
-        type Message = Command;
-        type Timeout = ();
-    }
-
     #[derive(Debug, Eq, PartialEq)]
     struct M;
     impl Handler for M {
@@ -157,25 +150,25 @@ mod test {
             }
         }
 
-        let event_loop = mio::deprecated::EventLoop::<S>::new().unwrap();
+        let (chn, _) = mio::channel::sync_channel(42);
 
         let mut x = X;
         let m = x.connection_made(
-            Sender::new(mio::Token(0), event_loop.channel())
+            Sender::new(mio::Token(0), chn)
         );
         assert_eq!(m, M);
     }
 
     #[test]
     fn closure_factory() {
-        let event_loop = mio::deprecated::EventLoop::<S>::new().unwrap();
+        let (chn, _) = mio::channel::sync_channel(42);
 
         let mut factory = |_| {
             |_| {Ok(())}
         };
 
         factory.connection_made(
-            Sender::new(mio::Token(0), event_loop.channel())
+            Sender::new(mio::Token(0), chn)
         );
     }
 
@@ -193,11 +186,11 @@ mod test {
             }
         }
 
-        let event_loop = mio::deprecated::EventLoop::<S>::new().unwrap();
+        let (chn, _) = mio::channel::sync_channel(42);
 
         let mut x = X;
         let m = x.connection_made(
-            Sender::new(mio::Token(0), event_loop.channel())
+            Sender::new(mio::Token(0), chn)
         );
         x.connection_lost(m);
     }

--- a/src/result.rs
+++ b/src/result.rs
@@ -46,7 +46,7 @@ pub enum Kind {
     /// `Settings::max_connections` and `Settings:queue_size` high enough to handle the load.
     /// If encountered, retuning from a handler method and waiting for the EventLoop to consume
     /// the queue may relieve the situation.
-    Queue(mio::deprecated::NotifyError<Command>),
+    Queue(mio::channel::SendError<Command>),
     /// Indicates a failure to schedule a timeout on the EventLoop.
     Timer(mio::timer::TimerError),
     /// Indicates a failure to perform SSL encryption.
@@ -158,11 +158,11 @@ impl From<httparse::Error> for Error {
 
 }
 
-impl From<mio::deprecated::NotifyError<Command>> for Error {
+impl From<mio::channel::SendError<Command>> for Error {
 
-    fn from(err: mio::deprecated::NotifyError<Command>) -> Error {
+    fn from(err: mio::channel::SendError<Command>) -> Error {
         match err {
-            mio::deprecated::NotifyError::Io(err) => Error::from(err),
+            mio::channel::SendError::Io(err) => Error::from(err),
             _ => Error::new(Kind::Queue(err), "")
         }
     }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,7 +1,7 @@
 use std::io;
+use std::io::ErrorKind::WouldBlock;
 use std::net::SocketAddr;
 
-use mio::deprecated::{TryRead, TryWrite};
 use mio::tcp::TcpStream;
 #[cfg(feature="ssl")]
 use openssl::ssl::SslStream;
@@ -11,7 +11,20 @@ use bytes::{Buf, MutBuf};
 
 use result::{Result, Error, Kind};
 
-pub trait TryReadBuf: TryRead {
+fn map_non_block<T>(res: io::Result<T>) -> io::Result<Option<T>> {
+    match res {
+        Ok(value) => Ok(Some(value)),
+        Err(err) => {
+            if let WouldBlock = err.kind() {
+                Ok(None)
+            } else {
+                Err(err)
+            }
+        }
+    }
+}
+
+pub trait TryReadBuf: io::Read {
     fn try_read_buf<B: MutBuf>(&mut self, buf: &mut B) -> io::Result<Option<usize>>
         where Self : Sized
     {
@@ -20,7 +33,7 @@ pub trait TryReadBuf: TryRead {
         // If your protocol is msg based (instead of continuous stream) you should
         // ensure that your buffer is large enough to hold an entire segment (1532 bytes if not jumbo
         // frames)
-        let res = self.try_read(unsafe { buf.mut_bytes() });
+        let res = map_non_block(self.read(unsafe { buf.mut_bytes() }));
 
         if let Ok(Some(cnt)) = res {
             unsafe { buf.advance(cnt); }
@@ -30,11 +43,11 @@ pub trait TryReadBuf: TryRead {
     }
 }
 
-pub trait TryWriteBuf: TryWrite {
+pub trait TryWriteBuf: io::Write {
     fn try_write_buf<B: Buf>(&mut self, buf: &mut B) -> io::Result<Option<usize>>
         where Self : Sized
     {
-        let res = self.try_write(buf.bytes());
+        let res = map_non_block(self.write(buf.bytes()));
 
         if let Ok(Some(cnt)) = res {
             buf.advance(cnt);
@@ -44,8 +57,8 @@ pub trait TryWriteBuf: TryWrite {
     }
 }
 
-impl<T: TryRead> TryReadBuf for T {}
-impl<T: TryWrite> TryWriteBuf for T {}
+impl<T: io::Read> TryReadBuf for T {}
+impl<T: io::Write> TryWriteBuf for T {}
 
 use self::Stream::*;
 pub enum Stream {
@@ -119,20 +132,20 @@ impl Stream {
     }
 }
 
-impl TryRead for Stream {
+impl io::Read for Stream {
 
-    fn try_read(&mut self, buf: &mut [u8]) -> io::Result<Option<usize>> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         match *self {
-            Tcp(ref mut sock) => sock.try_read(buf),
+            Tcp(ref mut sock) => sock.read(buf),
             #[cfg(feature="ssl")]
             Tls { ref mut sock, ref mut negotiating } => {
                 match sock.ssl_read(buf) {
-                    Ok(cnt) => Ok(Some(cnt)),
+                    Ok(cnt) => Ok(cnt),
                     Err(SslError::WantWrite(_)) => {
                         *negotiating = true;
-                        Ok(None)
+                        Err(io::Error::new(io::ErrorKind::WouldBlock, "SSL wants writing"))
                     },
-                    Err(SslError::WantRead(_)) => Ok(None),
+                    Err(SslError::WantRead(_)) => Err(io::Error::new(io::ErrorKind::WouldBlock, "SSL wants reading")),
                     Err(err) =>
                         Err(io::Error::new(io::ErrorKind::Other, err)),
                 }
@@ -141,27 +154,35 @@ impl TryRead for Stream {
     }
 }
 
-impl TryWrite for Stream {
+impl io::Write for Stream {
 
-    fn try_write(&mut self, buf: &[u8]) -> io::Result<Option<usize>> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         match *self {
-            Tcp(ref mut sock) => sock.try_write(buf),
+            Tcp(ref mut sock) => sock.write(buf),
             #[cfg(feature="ssl")]
             Tls { ref mut sock, ref mut negotiating } => {
 
                 *negotiating = false;
 
                 match sock.ssl_write(buf) {
-                    Ok(cnt) => Ok(Some(cnt)),
+                    Ok(cnt) => Ok(cnt),
                     Err(SslError::WantRead(_)) => {
                         *negotiating = true;
-                        Ok(None)
+                        Err(io::Error::new(io::ErrorKind::WouldBlock, "SSL wants reading"))
                     },
-                    Err(SslError::WantWrite(_)) => Ok(None),
+                    Err(SslError::WantWrite(_)) => Err(io::Error::new(io::ErrorKind::WouldBlock, "SSL wants writing")),
                     Err(err) =>
                         Err(io::Error::new(io::ErrorKind::Other, err)),
                 }
             }
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        match *self {
+            Tcp(ref mut sock) => sock.flush(),
+            #[cfg(feature="ssl")]
+            Tls { ref mut sock, negotiating: _ } => sock.flush(),
         }
     }
 }


### PR DESCRIPTION
This removes all references to mio::deprecated for MIO 0.6 and replaces EventLoop with Poll. Preparing ws-rs to be refactored to be more general and to be used together with Tokio.