### PR TITLE
Update to openssl 0.9 and fix #94

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ version = "*"
 
 [dependencies.openssl]
 optional = true
-version = "0.7.14"
+version = "*"
 
 [features]
 default = []

--- a/src/deflate/extension.rs
+++ b/src/deflate/extension.rs
@@ -1,7 +1,7 @@
 use std::mem::replace;
 
 #[cfg(feature="ssl")]
-use openssl::ssl::Ssl;
+use openssl::ssl::{SslConnector, SslAcceptor};
 use url;
 
 use handler::Handler;
@@ -515,8 +515,13 @@ impl<H: Handler> Handler for DeflateHandler<H> {
 
     #[inline]
     #[cfg(all(not(windows), feature="ssl"))]
-    fn build_ssl(&mut self) -> Result<Ssl> {
-        self.inner.build_ssl()
+    fn build_ssl_client(&mut self) -> Result<SslConnector> {
+        self.inner.build_ssl_client()
     }
 
+    #[inline]
+    #[cfg(all(not(windows), feature="ssl"))]
+    fn build_ssl_server(&mut self) -> Result<SslAcceptor> {
+        self.inner.build_ssl_server()
+    }
 }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,7 +1,7 @@
 use url;
 use log::LogLevel::Error as ErrorLevel;
 #[cfg(feature="ssl")]
-use openssl::ssl::{Ssl, SslContext, SslMethod};
+use openssl::ssl::{SslConnector, SslConnectorBuilder, SslAcceptor, SslMethod};
 
 use message::Message;
 use frame::Frame;
@@ -268,14 +268,23 @@ pub trait Handler {
         Request::from_url(url)
     }
 
-    /// A method for obtaining an Ssl object for use in wss connections.
+    /// A method for obtaining an Ssl object for use in wss client connections.
     ///
     /// Override this method to customize the Ssl object used to encrypt the connection.
     #[inline]
     #[cfg(feature="ssl")]
-    fn build_ssl(&mut self) -> Result<Ssl> {
-        let context = try!(SslContext::new(SslMethod::Tlsv1));
-        Ssl::new(&context).map_err(Error::from)
+    fn build_ssl_client(&mut self) -> Result<SslConnector> {
+        let builder = try!(SslConnectorBuilder::new(SslMethod::tls()));
+        Ok(builder.build())
+    }
+
+    /// A method for obtaining an Ssl object for use in wss server connections.
+    ///
+    /// Override this method to customize the Ssl object used to encrypt the connection.
+    #[inline]
+    #[cfg(feature="ssl")]
+    fn build_ssl_server(&mut self) -> Result<SslAcceptor> {
+        unimplemented!();
     }
 }
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -15,7 +15,7 @@ use mio::tcp::{TcpListener, TcpStream};
 use url::Url;
 
 #[cfg(feature="ssl")]
-use openssl::ssl::error::SslError;
+use openssl::ssl::Error as SslError;
 
 use communication::{Sender, Signal, Command};
 use result::{Result, Error, Kind};
@@ -144,7 +144,7 @@ impl<F> Handler<F>
         if url.scheme() == "wss" {
             while let Err(ssl_error) = self.connections[tok].encrypt() {
                 match ssl_error.kind {
-                    Kind::Ssl(SslError::StreamError(ref io_error)) => {
+                    Kind::Ssl(SslError::Stream(ref io_error)) => {
                         if let Some(errno) = io_error.raw_os_error() {
                             if errno == 111 {
                                 if let Err(reset_error) = self.connections[tok].reset() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,7 +215,7 @@ pub struct Settings {
     /// Indicate whether server connections should use ssl encryption when accepting connections.
     /// Setting this to true means that clients should use the `wss` scheme to connect to this
     /// server. Note that using this flag will in general necessitate overriding the
-    /// `Handler::build_ssl` method in order to provide the details of the ssl context. It may be
+    /// `Handler::build_ssl_server` method in order to provide the details of the ssl context. It may be
     /// simpler for most users to use a reverse proxy such as nginx to provide server side
     /// encryption.
     ///

--- a/src/result.rs
+++ b/src/result.rs
@@ -9,11 +9,14 @@ use std::convert::{From, Into};
 use httparse;
 use mio;
 #[cfg(feature="ssl")]
-use openssl::ssl::error::SslError;
+use openssl;
 
 use communication::Command;
 
 pub type Result<T> = StdResult<T, Error>;
+
+#[cfg(feature="ssl")]
+type HandshakeError = openssl::ssl::HandshakeError<mio::tcp::TcpStream>;
 
 /// The type of an error, which may indicate other kinds of errors as the underlying cause.
 #[derive(Debug)]
@@ -49,9 +52,15 @@ pub enum Kind {
     Queue(mio::deprecated::NotifyError<Command>),
     /// Indicates a failure to schedule a timeout on the EventLoop.
     Timer(mio::timer::TimerError),
+    /// Indicates that no valid domain name is given in the URL.
+    #[cfg(feature="ssl")]
+    NoDomain,
+    /// Indicates a failure to perform SSL handshake.
+    #[cfg(feature="ssl")]
+    SslHandshake(HandshakeError),
     /// Indicates a failure to perform SSL encryption.
     #[cfg(feature="ssl")]
-    Ssl(SslError),
+    Ssl(openssl::ssl::Error),
     /// A custom error kind for use by applications. This error kind involves extra overhead
     /// because it will allocate the memory on the heap. The WebSocket ignores such errors by
     /// default, simply passing them to the Connection Handler.
@@ -115,6 +124,10 @@ impl StdError for Error {
             Kind::Io(ref err)       => err.description(),
             Kind::Http(_)          => "Unable to parse HTTP",
             #[cfg(feature="ssl")]
+            Kind::NoDomain          => "No domain name given",
+            #[cfg(feature="ssl")]
+            Kind::SslHandshake(ref err) => err.description(),
+            #[cfg(feature="ssl")]
             Kind::Ssl(ref err)      => err.description(),
             Kind::Queue(_)          => "Unable to send signal on event loop",
             Kind::Timer(_)          => "Unable to schedule timeout on event loop",
@@ -126,6 +139,8 @@ impl StdError for Error {
         match self.kind {
             Kind::Encoding(ref err) => Some(err),
             Kind::Io(ref err)       => Some(err),
+            #[cfg(feature="ssl")]
+            Kind::SslHandshake(ref err) => Some(err),
             #[cfg(feature="ssl")]
             Kind::Ssl(ref err)      => Some(err),
             Kind::Custom(ref err)   => Some(err.as_ref()),
@@ -186,9 +201,23 @@ impl From<Utf8Error> for Error {
 }
 
 #[cfg(feature="ssl")]
-impl From<SslError> for Error {
-    fn from(err: SslError) -> Error {
+impl From<openssl::ssl::Error> for Error {
+    fn from(err: openssl::ssl::Error) -> Error {
         Error::new(Kind::Ssl(err), "")
+    }
+}
+
+#[cfg(feature="ssl")]
+impl From<HandshakeError> for Error {
+    fn from(err: HandshakeError) -> Error {
+        Error::new(Kind::SslHandshake(err), "")
+    }
+}
+
+#[cfg(feature="ssl")]
+impl From<openssl::error::ErrorStack> for Error {
+    fn from(err: openssl::error::ErrorStack) -> Error {
+        Error::from(openssl::ssl::Error::Ssl(err))
     }
 }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -6,7 +6,7 @@ use mio::tcp::TcpStream;
 #[cfg(feature="ssl")]
 use openssl::ssl::SslStream;
 #[cfg(feature="ssl")]
-use openssl::ssl::error::Error as SslError;
+use openssl::ssl::Error as SslError;
 use bytes::{Buf, MutBuf};
 
 use result::{Result, Error, Kind};


### PR DESCRIPTION
This updates to OpenSSL 0.9.x and fixes the SNI issue.

NB: breaking change! Due to OpenSSL security issues the build_ssl() method of the trait is now replaced by distinct build_ssl_client() and build_ssl_server() with different return types.