### PR TITLE
Allow arbitrary handshake responses and split binding to interface from running the server.

### DIFF
--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -184,6 +184,12 @@ impl Request {
         }
     }
 
+    /// Get the request method.
+    #[inline]
+    pub fn method(&self) -> &str {
+      &self.method
+    }
+
     /// Get the path of the request.
     #[allow(dead_code)]
     #[inline]
@@ -428,9 +434,9 @@ impl Response {
 
     /// Set the response body.
     #[inline]
-    pub fn set_body(&mut self, body: &[u8]) {
-        self.body = body.to_vec();
-        let len = format!("{}", body.len()).as_bytes().to_vec();
+    pub fn set_body<T: Into<Vec<u8>>>(&mut self, body: T) {
+        self.body = body.into();
+        let len = format!("{}", self.body.len()).as_bytes().to_vec();
 
         if let Some(header) = self.header_mut("content-length") {
             *header = len;

--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -403,10 +403,42 @@ pub struct Response {
     status: u16,
     reason: String,
     headers: Vec<(String, Vec<u8>)>,
+    body: Vec<u8>,
 }
 
 impl Response {
     // TODO: resolve the overlap with Request
+
+    pub fn new<R>(status: u16, reason: R) -> Response
+        where R: Into<String>,
+    {
+        Response {
+            status: status,
+            reason: reason.into(),
+            headers: Vec::new(),
+            body: Vec::new(),
+        }
+    }
+
+    /// Get the response body.
+    #[inline]
+    pub fn body(&self) -> &[u8] {
+        &self.body
+    }
+
+    /// Set the response body.
+    #[inline]
+    pub fn set_body(&mut self, body: &[u8]) {
+        self.body = body.to_vec();
+        let len = format!("{}", body.len()).as_bytes().to_vec();
+
+        if let Some(header) = self.header_mut("content-length") {
+            *header = len;
+            return;
+        }
+
+        self.headers.push(("Content-Length".into(), len));
+    }
 
     /// Get the value of the first instance of an HTTP header.
     fn header(&self, header: &str) -> Option<&Vec<u8>> {
@@ -548,6 +580,7 @@ impl Response {
                 status: res.code.unwrap(),
                 reason: res.reason.unwrap().into(),
                 headers: res.headers.iter().map(|h| (h.name.into(), h.value.into())).collect(),
+                body: Vec::new(),
             }))
         } else {
             Ok(None)
@@ -566,6 +599,7 @@ impl Response {
                 ("Sec-WebSocket-Accept".into(), try!(req.hashed_key()).into()),
                 ("Upgrade".into(), "websocket".into()),
             ],
+            body: Vec::new(),
         };
 
         debug!("Built response from request:\n{}", res);
@@ -583,6 +617,7 @@ impl Response {
             try!(write!(w, "\r\n"));
         }
         try!(write!(w, "\r\n"));
+        try!(w.write(&self.body));
         Ok(())
     }
 }


### PR DESCRIPTION
The first set of changes regarding `Response` object allows you to return a more descriptive responses to failed handshake messages (like `Origin` validation failed). It enables serving arbitrary content using the server as well by returning `200 OK` responses with some body.

Second change allows you to `bind` the server to the interface first and run it afterwards. The reason for this is that if the server is started in another thread you can properly handle/propagate bind-related IO errors (like address in use). Another use case would be to get a randomly assigned port when trying to listen on e.g. `127.0.0.1:0` but this requires a bit more digging.