### PR TITLE
Expose local_addr method to get address socket is bound to

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -2,7 +2,7 @@ use std::net::{SocketAddr, ToSocketAddrs};
 use std::borrow::Borrow;
 use std::time::Duration;
 use std::usize;
-use std::io::ErrorKind;
+use std::io::{ErrorKind, Error as IoError};
 
 use mio;
 use mio::{
@@ -129,6 +129,14 @@ impl<F> Handler<F>
         try!(poll.register(&tcp, ALL, Ready::readable(), PollOpt::level()));
         self.listener = Some(tcp);
         Ok(self)
+    }
+
+    pub fn local_addr(&self) -> ::std::io::Result<SocketAddr> {
+        if let Some(ref listener) = self.listener {
+            listener.local_addr()
+        } else {
+            Err(IoError::new(ErrorKind::NotFound, "Not a listening socket"))
+        }
     }
 
     #[cfg(feature="ssl")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ pub use handshake::{Handshake, Request, Response};
 
 use std::fmt;
 use std::default::Default;
-use std::net::ToSocketAddrs;
+use std::net::{SocketAddr, ToSocketAddrs};
 use std::borrow::Borrow;
 
 use mio::Poll;
@@ -292,6 +292,7 @@ impl<F> WebSocket<F>
 
         for addr in try!(addr_spec.to_socket_addrs()) {
             result = self.handler.listen(&mut self.poll, &addr).map(|_| ());
+            let addr = self.handler.local_addr().unwrap_or(addr);
             if result.is_ok() {
                 info!("Listening for new connections on {}.", addr);
                 return self.run()
@@ -324,6 +325,13 @@ impl<F> WebSocket<F>
     #[inline]
     pub fn broadcaster(&self) -> Sender {
         self.handler.sender()
+    }
+
+    /// Get the local socket address this socket is bound to. Will return an error
+    /// if the backend returns an error. Will return a `NotFound` error if
+    /// this WebSocket is not a listening socket.
+    pub fn local_addr(&self) -> ::std::io::Result<SocketAddr> {
+        self.handler.local_addr()
     }
 }
 


### PR DESCRIPTION
When binding to port zero the OS will assign a random port. With the current version of `ws` it's impossible to know which port is being assigned. This PR fixes that by exposing a `local_addr` method first in the `Handler` and then in the `WebSocket` structs.

It is still not possible to actually query for the address since the only method actually binding is also blocking on listening. But my end goal after this is to help get #133 merged, and then this will be very helpful. In the meantime this fix at least makes the logging output correct when binding to port zero.