### PR TITLE
Separate listen and bind methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,12 +280,10 @@ impl<F> WebSocket<F>
         Builder::new().build(factory)
     }
 
-    /// Consume the WebSocket and listen for new connections on the specified address.
-    ///
-    /// # Safety
-    ///
-    /// This method will block until the event loop finishes running.
-    pub fn listen<A>(mut self, addr_spec: A) -> Result<WebSocket<F>>
+    /// Consume the WebSocket and binds to the specified address.
+    /// After the server is succesfully bound you should start it
+    /// using `run()`
+    pub fn bind<A>(mut self, addr_spec: A) -> Result<WebSocket<F>>
         where A: ToSocketAddrs + fmt::Debug
     {
         let mut result = Err(Error::new(ErrorKind::Internal, format!("Unable to listen on {:?}", addr_spec)));
@@ -295,11 +293,21 @@ impl<F> WebSocket<F>
             let addr = self.handler.local_addr().unwrap_or(addr);
             if result.is_ok() {
                 info!("Listening for new connections on {}.", addr);
-                return self.run()
             }
         }
 
         result.map(|_| self)
+    }
+
+    /// Consume the WebSocket and listen for new connections on the specified address.
+    ///
+    /// # Safety
+    ///
+    /// This method will block until the event loop finishes running.
+    pub fn listen<A>(self, addr_spec: A) -> Result<WebSocket<F>>
+        where A: ToSocketAddrs + fmt::Debug
+    {
+        self.bind(addr_spec).and_then(|server| server.run())
     }
 
     /// Queue an outgoing connection on this WebSocket. This method may be called multiple times,

--- a/tests/bind.rs
+++ b/tests/bind.rs
@@ -1,0 +1,18 @@
+extern crate ws;
+
+use std::net::Ipv4Addr;
+
+struct Handler;
+impl ws::Handler for Handler {}
+
+#[test]
+fn bind_port_zero() {
+    let ws = ws::WebSocket::new(|_sender| Handler).unwrap();
+    let ws = ws.bind("127.0.0.1:0").unwrap();
+
+    let local_addr = ws.local_addr().unwrap();
+    println!("Listening on {}", local_addr);
+
+    assert_eq!(Ipv4Addr::new(127, 0, 0, 1), local_addr.ip());
+    assert_ne!(0, local_addr.port());
+}

--- a/tests/bind.rs
+++ b/tests/bind.rs
@@ -16,3 +16,16 @@ fn bind_port_zero() {
     assert_eq!(Ipv4Addr::new(127, 0, 0, 1), local_addr.ip());
     assert_ne!(0, local_addr.port());
 }
+
+#[test]
+fn bind_try_multiple_addrs() {
+    let invalid_addr = "99.99.99.99:0".parse().unwrap();
+    let valid_addr = "127.0.0.1:9876".parse().unwrap();
+    let addrs = vec![invalid_addr, valid_addr, invalid_addr];
+
+    let ws = ws::WebSocket::new(|_sender| Handler).unwrap();
+    let ws = ws.bind(&addrs[..]).unwrap();
+
+    let local_addr = ws.local_addr().unwrap();
+    assert_eq!(valid_addr, local_addr);
+}


### PR DESCRIPTION
My goal is to bring in the functionality of #133, but I don't have commit access to that repo, and it had to be rebased anyway, so I'm bringing the commits in here instead.

This PR brings in the first commit, separating `bind` from `listen` and adds a test for that using the newly merged `local_addr` method. It also takes care of returning after the first successful bind and states that in the docs.