### PR TITLE
Fix issue where on_close isn't called when a client is abruptly dropped

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -24,6 +24,7 @@ use connection::Connection;
 use factory::Factory;
 use util::Slab;
 use super::Settings;
+use CloseCode;
 
 const QUEUE: Token = Token(usize::MAX - 3);
 const TIMER: Token = Token(usize::MAX - 4);
@@ -459,7 +460,7 @@ impl<F> Handler<F>
 
     #[inline]
     fn check_active(&mut self, poll: &mut Poll, active: bool, token: Token) {
-
+        use Handler;
         // NOTE: Closing state only applies after a ws connection was successfully
         // established. It's possible that we may go inactive while in a connecting
         // state if the handshake fails.
@@ -469,7 +470,8 @@ impl<F> Handler<F>
             } else {
                 trace!("WebSocket connection to token={:?} disconnected.", token);
             }
-            let handler = self.connections.remove(token).unwrap().consume();
+            let mut handler = self.connections.remove(token).unwrap().consume();
+            handler.on_close(CloseCode::Abnormal, "");
             self.factory.connection_lost(handler);
         } else {
             self.schedule(poll, &self.connections[token]).or_else(|err| {


### PR DESCRIPTION
Easiest way to repro this issue is to create a client that connects to the server and keeps the connection open.  Ctrl+C out of the client so it doesn't have a chance to properly close the connection.