### PR TITLE
fix: typo

### DIFF
--- a/src/communication.rs
+++ b/src/communication.rs
@@ -188,8 +188,8 @@ impl Sender {
 
     /// Queue the cancellation of a previously scheduled timeout.
     ///
-    /// This method is not guaranteed to prevent the timeout from occuring, because it is
-    /// possible to call this method after a timeout has already occured. It is still necessary to
+    /// This method is not guaranteed to prevent the timeout from occurring, because it is
+    /// possible to call this method after a timeout has already occurred. It is still necessary to
     /// handle spurious timeouts.
     #[inline]
     pub fn cancel(&self, timeout: mio::timer::Timeout) -> Result<()> {

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -253,7 +253,7 @@ pub trait Handler {
     /// A method for creating the initial handshake request for WebSocket clients.
     ///
     /// The default implementation provides conformance with the WebSocket protocol, but this
-    /// method may be overriden. In order to facilitate conformance,
+    /// method may be overridden. In order to facilitate conformance,
     /// implementors should use the `Request::from_url` method and then modify the resulting
     /// request as necessary.
     ///

--- a/src/io.rs
+++ b/src/io.rs
@@ -414,7 +414,7 @@ impl<F> Handler<F>
                             error!("Websocket shutting down for interrupt.");
                             self.state = State::Inactive;
                         } else {
-                            error!("Websocket received interupt.");
+                            error!("Websocket received interrupt.");
                         }
                         0
                     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,7 +204,7 @@ pub struct Settings {
     pub masking_strict: bool,
     /// The WebSocket protocol requires clients to verify the key returned by a server to ensure
     /// that the server and all intermediaries can perform the protocol. Verifying the key will
-    /// consume processing time and other resources with the benifit that we can fail the
+    /// consume processing time and other resources with the benefit that we can fail the
     /// connection early. The default in WS-RS is to accept any key from the server and instead
     /// fail late if a protocol error occurs. Change this setting to enable key verification.
     /// Default: false
@@ -285,7 +285,7 @@ impl<F> WebSocket<F>
     /// If the `addr_spec` yields multiple addresses this will return after the
     /// first successful bind. `local_addr` can be called to determine which
     /// address it ended up binding to.
-    /// After the server is succesfully bound you should start it using `run`.
+    /// After the server is successfully bound you should start it using `run`.
     pub fn bind<A>(mut self, addr_spec: A) -> Result<WebSocket<F>>
         where A: ToSocketAddrs
     {

--- a/src/result.rs
+++ b/src/result.rs
@@ -30,7 +30,7 @@ pub enum Kind {
     Capacity,
     /// Indicates a violation of the WebSocket protocol.
     /// The WebSocket will automatically attempt to send a Protocol (1002) close code, or if
-    /// this error occurs during a handshake, an HTTP 400 reponse will be generated.
+    /// this error occurs during a handshake, an HTTP 400 response will be generated.
     Protocol,
     /// Indicates that the WebSocket received data that should be utf8 encoded but was not.
     /// The WebSocket will automatically attempt to send a Invalid Frame Payload Data (1007) close
@@ -63,7 +63,7 @@ pub enum Kind {
     Custom(Box<StdError + Send + Sync>),
 }
 
-/// A struct indicating the kind of error that has occured and any precise details of that error.
+/// A struct indicating the kind of error that has occurred and any precise details of that error.
 pub struct Error {
     pub kind: Kind,
     pub details: Cow<'static, str>,


### PR DESCRIPTION
Fixed typo found by `yaspeller`. One can also check typo by `npx yaspeller -e '.rs' ./src`.