### PR TITLE
Avoid integer overflow when parsing frame bytes.

### DIFF
--- a/src/frame.rs
+++ b/src/frame.rs
@@ -305,10 +305,14 @@ impl Frame {
             None
         };
 
-        if size < length + header_length {
-            cursor.set_position(initial);
-            return Ok(None)
-        }
+        match length.checked_add(header_length) {
+            Some(l) if size < l => {
+                cursor.set_position(initial);
+                return Ok(None);
+            }
+            Some(_) => (),
+            None => return Ok(None),
+        };
 
         let mut data = Vec::with_capacity(length as usize);
         if length > 0 {


### PR DESCRIPTION
The following program causes a panic, prior to these changes.

```rust
extern crate ws;

fn main() {
    let bytes = b"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xfe\xfe\xfe\xfe\xfe\t\x01\xfe\xfe\xfe\xfe\xfe\xfe\xfe\xfe\xfe\xfe\xfe\xfe\xfe\xfe\xfe\xfe\xfe\xfe\xfe\xfe\xfe\xfe\xb1\n".to_vec();
    let mut data = std::io::Cursor::new(bytes);
    ws::Frame::parse(&mut data);
}
```

Found via [cargo-fuzz](https://github.com/rust-fuzz/cargo-fuzz).