### PR TITLE
Add custom responses and include a chat example

### DIFF
--- a/examples/html_chat.rs
+++ b/examples/html_chat.rs
@@ -1,0 +1,66 @@
+/// An example of a chat web application server
+extern crate ws;
+use ws::{listen, Handler, Message, Request, Response, Result, Sender};
+
+// This can be read from a file
+static INDEX_HTML: &'static [u8] = br#"
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="utf-8">
+	</head>
+	<body>
+      <pre id="messages"></pre>
+			<form id="form">
+				<input type="text" id="msg">
+				<input type="submit" value="Send">
+			</form>
+      <script>
+        var socket = new WebSocket("ws://" + window.location.host + "/ws");
+        socket.onmessage = function (event) {
+          var messages = document.getElementById("messages");
+          messages.append(event.data + "\n");
+        };
+        var form = document.getElementById("form");
+        form.addEventListener('submit', function (event) {
+          event.preventDefault();
+          var input = document.getElementById("msg");
+          socket.send(input.value);
+          input.value = "";
+        });
+		</script>
+	</body>
+</html>
+    "#;
+
+// Server web application handler
+struct Server {
+  out: Sender,
+}
+
+impl Handler for Server {
+  //
+  fn on_request(&mut self, req: &Request) -> Result<(Response)> {
+    // Using multiple handlers is better (see router example)
+    match req.resource() {
+      // The default trait implementation
+      "/ws" => Response::from_request(req),
+
+      // Create a custom response
+      "/" => Ok(Response::new(200, "OK", INDEX_HTML.to_vec())),
+
+      _ => Ok(Response::new(404, "Not Found", b"404 - Not Found".to_vec())),
+    }
+  }
+
+  // Handle messages recieved in the websocket (in this case, only on /ws)
+  fn on_message(&mut self, msg: Message) -> Result<()> {
+    // Broadcast to all connections
+    self.out.broadcast(msg)
+  }
+}
+
+fn main() {
+  // Listen on an address and call the closure for each connection
+  listen("127.0.0.1:8000", |out| Server { out }).unwrap()
+}

--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -412,34 +412,22 @@ pub struct Response {
 impl Response {
     // TODO: resolve the overlap with Request
 
-    pub fn new<R>(status: u16, reason: R) -> Response
-        where R: Into<String>,
-    {
-        Response {
-            status: status,
-            reason: reason.into(),
-            headers: Vec::new(),
-            body: Vec::new(),
+    /// Construct a generic HTTP response with a body.
+    pub fn new<R>(status: u16, reason: R, body: Vec<u8>) -> Response
+            where R: Into<String>,
+        {
+            Response {
+                status: status,
+                reason: reason.into(),
+                headers: vec![("Content-Length".into(), body.len().to_string().into())],
+                body: body
+            }
         }
-    }
 
     /// Get the response body.
     #[inline]
     pub fn body(&self) -> &[u8] {
         &self.body
-    }
-
-    /// Set the response body.
-    #[inline]
-    pub fn set_body<T: Into<Vec<u8>>>(&mut self, body: T) {
-        self.body = body.into();
-        let len_header = "Content-Length".to_owned();
-        let len = format!("{}", self.body.len()).as_bytes().to_vec();
-        if let Some(header) = self.header_mut(&len_header) {
-            *header = len;
-            return;
-        }
-        self.headers.push((len_header, len));
     }
 
     /// Get the value of the first instance of an HTTP header.


### PR DESCRIPTION
This builds off of #133. I have removed `set_body` and moved it to the `new` response method signature instead. This prevents valid websocket responses from being accidentally corrupted while allowing simple (or not) HTTP handlers to be built alongside. 

I have also included a sample chat example that has an index page, a broadcast message handler and even a 404 handler.

This should also fix #86 