### PR TITLE
Add on_send_message method to Handler

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -871,6 +871,16 @@ impl<H> Connection<H>
             return Ok(())
         }
 
+        // Pass message to `on_send_message` handler method,
+        // where it may be modified or dropped.
+        let msg = match try!(self.handler.on_send_message(msg)) {
+            Some(msg) => msg,
+            None => {
+                trace!("Dropped message by `on_send_message`");
+                return Ok(());
+            },
+        };
+
         let opcode = msg.opcode();
         trace!("Message opcode {:?}", opcode);
         let data = msg.into_data();

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -43,6 +43,14 @@ pub trait Handler {
         Ok(())
     }
 
+    /// Called on outgoing messages.
+    ///
+    /// Returning `Ok(None)` will cause the connection to forget about a
+    /// particular message, meaning that it will not be sent.
+    fn on_send_message(&mut self, msg: Message) -> Result<Option<Message>> {
+        Ok(Some(msg))
+    }
+
     /// Called any time this endpoint receives a close control frame.
     /// This may be because the other endpoint is initiating a closing handshake,
     /// or it may be the other endpoint confirming the handshake initiated by this endpoint.


### PR DESCRIPTION
This is analogue to `on_send_frame`. While `on_send_frame` is also called for messages prior to fragmentation, that's a low-level method called for any frame, no matter whether it's a user defined message or something else (like a frame from a close message).