### PR TITLE
clippy: fix the examples

### DIFF
--- a/examples/autobahn-client.rs
+++ b/examples/autobahn-client.rs
@@ -8,7 +8,7 @@ use ws::{connect, CloseCode, Message, Result};
 #[cfg(feature = "permessage-deflate")]
 use ws::deflate::DeflateHandler;
 
-const AGENT: &'static str = "WS-RS";
+const AGENT: &str = "WS-RS";
 
 #[cfg(not(feature = "permessage-deflate"))]
 fn main() {

--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -34,7 +34,8 @@ fn main() {
         fn on_open(&mut self, _: Handshake) -> Result<()> {
             self.out.send(MESSAGE)?;
             self.count += 1;
-            Ok(self.time = time::precise_time_ns())
+            self.time = time::precise_time_ns();
+            Ok(())
         }
 
         fn on_message(&mut self, msg: Message) -> Result<()> {
@@ -59,7 +60,7 @@ fn main() {
             ..Settings::default()
         })
         .build(|out| Connection {
-            out: out,
+            out,
             count: 0,
             time: 0,
             total: 0,

--- a/examples/channel.rs
+++ b/examples/channel.rs
@@ -111,7 +111,7 @@ fn main() {
         .spawn(move || {
             connect("ws://127.0.0.1:3012", |out| {
                 Client {
-                    out: out,
+                    out,
                     ind: 0,
                     // we need to clone again because
                     // in theory, there could be many client connections sending off the data

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -76,7 +76,7 @@ fn main() {
                         println!("Closing with code: {:?}, please wait...", code);
                         sender.close(code).unwrap();
                     } else {
-                        display(format!("Unable to parse {} as close code.", args[1]));
+                        display(&format!("Unable to parse {} as close code.", args[1]));
                         // Keep accepting input if the close arguments are invalid
                         continue;
                     }
@@ -94,7 +94,7 @@ fn main() {
                             .close_with_reason(code, reason.trim().to_string())
                             .unwrap();
                     } else {
-                        display(format!("Unable to parse {} as close code.", args[1]));
+                        display(&format!("Unable to parse {} as close code.", args[1]));
                         // Keep accepting input if the close arguments are invalid
                         continue;
                     }
@@ -102,7 +102,7 @@ fn main() {
                 break;
             } else {
                 // Send the message
-                display(format!(">>> {}", input.trim()));
+                display(&format!(">>> {}", input.trim()));
                 sender.send(input.trim()).unwrap();
             }
         }
@@ -112,7 +112,7 @@ fn main() {
     client.join().unwrap();
 }
 
-fn display(string: String) {
+fn display(string: &str) {
     let mut view = term::stdout().unwrap();
     view.carriage_return().unwrap();
     view.delete_line().unwrap();
@@ -147,29 +147,30 @@ impl Handler for Client {
     }
 
     fn on_message(&mut self, msg: Message) -> Result<()> {
-        Ok(display(format!("<<< {}", msg)))
+        display(&format!("<<< {}", msg));
+        Ok(())
     }
 
     fn on_close(&mut self, code: CloseCode, reason: &str) {
         if reason.is_empty() {
-            display(format!(
+            display(&format!(
                 "<<< Closing<({:?})>\nHit any key to end session.",
                 code
             ));
         } else {
-            display(format!(
+            display(&format!(
                 "<<< Closing<({:?}) {}>\nHit any key to end session.",
                 code, reason
             ));
         }
 
         if let Err(err) = self.thread_out.send(Event::Disconnect) {
-            display(format!("{:?}", err))
+            display(&format!("{:?}", err))
         }
     }
 
     fn on_error(&mut self, err: Error) {
-        display(format!("<<< Error<{:?}>", err))
+        display(&format!("<<< Error<{:?}>", err))
     }
 }
 

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -12,7 +12,7 @@ fn main() {
     // Connect to the url and call the closure
     if let Err(error) = connect("ws://127.0.0.1:3012", |out| {
         // Queue a message to be sent when the WebSocket is open
-        if let Err(_) = out.send("Hello WebSocket") {
+        if out.send("Hello WebSocket").is_err() {
             println!("Websocket couldn't queue an initial message.")
         } else {
             println!("Client sent message 'Hello WebSocket'. ")

--- a/examples/external_shutdown.rs
+++ b/examples/external_shutdown.rs
@@ -13,7 +13,10 @@ fn main() {
             tx.send(out).unwrap();
 
             // Dummy message handler
-            move |_| Ok(println!("Message handler called."))
+            move |_| {
+                println!("Message handler called.");
+                Ok(())
+            }
         })
         .unwrap();
 
@@ -26,7 +29,7 @@ fn main() {
     // Wait for 5 seconds only for incoming connections;
     thread::sleep(Duration::from_millis(5000));
 
-    if let Err(_) = rx.try_recv() {
+    if rx.try_recv().is_err() {
         // shutdown the server from the outside
         handle.shutdown().unwrap();
         println!("Shutting down server because no connections were established.");

--- a/examples/peer2peer.rs
+++ b/examples/peer2peer.rs
@@ -64,7 +64,10 @@ fn main() {
 
     // Create simple websocket that just prints out messages
     let mut me = ws::WebSocket::new(|_| {
-        move |msg| Ok(info!("Peer {} got message: {}", my_addr, msg))
+        move |msg| {
+            info!("Peer {} got message: {}", my_addr, msg);
+            Ok(())
+        }
     }).unwrap();
 
     // Get a sender for ALL connections to the websocket

--- a/examples/pong.rs
+++ b/examples/pong.rs
@@ -21,7 +21,7 @@ fn main() {
 
     // Run the WebSocket
     listen("127.0.0.1:3012", |out| Server {
-        out: out,
+        out,
         ping_timeout: None,
         expire_timeout: None,
     }).unwrap();

--- a/examples/router.rs
+++ b/examples/router.rs
@@ -109,7 +109,7 @@ struct Data {
 
 impl ws::Handler for Data {
     fn on_open(&mut self, _: ws::Handshake) -> ws::Result<()> {
-        for msg in self.data.iter() {
+        for msg in &self.data {
             self.ws.send(*msg)?
         }
         Ok(())

--- a/examples/threaded.rs
+++ b/examples/threaded.rs
@@ -32,8 +32,7 @@ fn main() {
     }
 
     // Server thread
-    let server =
-        thread::spawn(move || listen("127.0.0.1:3012", |out| Server { out: out }).unwrap());
+    let server = thread::spawn(move || listen("127.0.0.1:3012", |out| Server { out }).unwrap());
 
     // Give the server a little time to get going
     sleep(Duration::from_millis(10));


### PR DESCRIPTION
In the previous PR I only fixed the crate's code. This commit fixes clippy lints in the examples.