### PR TITLE
Adds a Sender::factory_timeout method.

### DIFF
--- a/src/communication.rs
+++ b/src/communication.rs
@@ -10,7 +10,7 @@ use message;
 use result::{Error, Result};
 use protocol::CloseCode;
 use std::cmp::PartialEq;
-use io::ALL;
+use io::{ALL, SYSTEM};
 
 #[derive(Debug, Clone)]
 pub enum Signal {
@@ -207,6 +207,19 @@ impl Sender {
                 token: self.token,
                 signal: Signal::Timeout { delay: ms, token },
                 connection_id: self.connection_id,
+            })
+            .map_err(Error::from)
+    }
+
+    /// Schedule a `token` to be sent to the WebSocket Factory's `on_timeout` method
+    /// after `ms` milliseconds
+    #[inline]
+    pub fn factory_timeout(&self, ms: u64, token: Token) -> Result<()> {
+        self.channel
+            .send(Command {
+                token: SYSTEM,
+                signal: Signal::Timeout { delay: ms, token },
+                connection_id: 0,
             })
             .map_err(Error::from)
     }

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -1,5 +1,6 @@
 use handler::Handler;
 use communication::Sender;
+use util::Token;
 
 /// A trait for creating new WebSocket handlers.
 pub trait Factory {
@@ -99,6 +100,13 @@ pub trait Factory {
     /// state that was not internally tracked by the handler.
     #[inline]
     fn connection_lost(&mut self, _: Self::Handler) {}
+
+    /// Called in response to a previous factory_timeout call.
+    ///
+    /// A factory_timeout call can be made when a connection is
+    /// lost in order to schedule another connection attempt.
+    #[inline]
+    fn on_timeout(&mut self, _ws: Sender, _event: Token) {}
 }
 
 impl<F, H> Factory for F

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,6 +198,9 @@ pub struct Settings {
     /// Whether to shutdown the eventloop when an interrupt is received.
     /// Default: true
     pub shutdown_on_interrupt: bool,
+    /// Whether to shutdown the eventloop when a client has no more connections.
+    /// Default: true
+    pub shutdown_unconnected_client: bool,
     /// The WebSocket protocol requires frames sent from client endpoints to be masked as a
     /// security and sanity precaution. Enforcing this requirement, which may be removed at some
     /// point may cause incompatibilities. If you need the extra security, set this to true.
@@ -255,6 +258,7 @@ impl Default for Settings {
             panic_on_io: false,
             panic_on_timeout: false,
             shutdown_on_interrupt: true,
+            shutdown_unconnected_client: true,
             masking_strict: false,
             key_strict: false,
             method_strict: false,


### PR DESCRIPTION
This is in response to issue #211. 

By allowing timeouts to be set for the factory, and also adding an option to enable a client to keep running with no connections, we make it possible for a client which has become disconnected for any reason (or was even unable to connect in the first place) to make repeated connection attempts.

A timeout can be set in lost_connection (using a Sender from the outgoing Handler, which is unfortunate, but perhaps unavoidable) and then a new connection can be created in the (newly added) on_timeout method of the factory.