### PR TITLE
Add support for basic authentication in Request::from_url

### DIFF
--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -351,26 +351,33 @@ impl Request {
             "".into()
         };
 
+        let mut headers = vec![
+            ("Connection".into(), "Upgrade".into()),
+            (
+                "Host".into(),
+                format!(
+                    "{}:{}",
+                    url.host_str().ok_or_else(|| Error::new(
+                        Kind::Internal,
+                        "No host passed for WebSocket connection.",
+                    ))?,
+                    url.port_or_known_default().unwrap_or(80)
+                ).into(),
+            ),
+            ("Sec-WebSocket-Version".into(), "13".into()),
+            ("Sec-WebSocket-Key".into(), generate_key().into()),
+            ("Upgrade".into(), "websocket".into()),
+        ];
+
+        if url.password().is_some() || url.username() != "" {
+            let basic = encode_base64(format!("{}:{}", url.username(), url.password().unwrap_or("")).as_bytes());
+            headers.push(("Authorization".into(), format!("Basic {}", basic).into()))
+        }
+
         let req = Request {
             path: format!("{}{}", url.path(), query),
             method: "GET".to_owned(),
-            headers: vec![
-                ("Connection".into(), "Upgrade".into()),
-                (
-                    "Host".into(),
-                    format!(
-                        "{}:{}",
-                        url.host_str().ok_or_else(|| Error::new(
-                            Kind::Internal,
-                            "No host passed for WebSocket connection.",
-                        ))?,
-                        url.port_or_known_default().unwrap_or(80)
-                    ).into(),
-                ),
-                ("Sec-WebSocket-Version".into(), "13".into()),
-                ("Sec-WebSocket-Key".into(), generate_key().into()),
-                ("Upgrade".into(), "websocket".into()),
-            ],
+            headers: headers,
         };
 
         debug!("Built request from URL:\n{}", req);


### PR DESCRIPTION
The spec doesn't say anything about empty passwords or usernames but
both seems to be valid so I allowed both cases here.