### PR TITLE
Add impl Debug for Sender

### DIFF
--- a/src/communication.rs
+++ b/src/communication.rs
@@ -11,6 +11,7 @@ use message;
 use protocol::CloseCode;
 use result::{Error, Result};
 use std::cmp::PartialEq;
+use std::fmt;
 
 #[derive(Debug, Clone)]
 pub enum Signal {
@@ -52,6 +53,13 @@ pub struct Sender {
     token: Token,
     channel: mio::channel::SyncSender<Command>,
     connection_id: u32,
+}
+
+impl fmt::Debug for Sender {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Sender {{ token: {:?}, channel: _, connection_id: {:?} }}",
+            self.token, self.connection_id)
+    }
 }
 
 impl PartialEq for Sender {

--- a/src/communication.rs
+++ b/src/communication.rs
@@ -57,7 +57,8 @@ pub struct Sender {
 
 impl fmt::Debug for Sender {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Sender {{ token: {:?}, channel: _, connection_id: {:?} }}",
+        write!(f,
+            "Sender {{ token: {:?}, channel: mio::channel::SyncSender<Command>, connection_id: {:?} }}",
             self.token, self.connection_id)
     }
 }


### PR DESCRIPTION
Close https://github.com/housleyjk/ws-rs/issues/162

`mio::channel::SyncSender` doesn't `impl Debug`, so I just left it out as _.