### PR TITLE
Feature/fix readiness

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ version = "0.10"
 
 [dependencies.native-tls]
 optional = true
-version = "0.1.5"
+version = "0.2"
 
 [dev-dependencies]
 clap = "2.31.2"

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -182,7 +182,7 @@ where
                 HandshakeError::Failure(_) => {
                     Err(Error::new(Kind::SslHandshake(handshake_err), details))
                 }
-                HandshakeError::Interrupted(mid) => {
+                HandshakeError::WouldBlock(mid) => {
                     self.socket = Stream::tls(mid);
                     Ok(())
                 }
@@ -252,7 +252,7 @@ where
                                 HandshakeError::Failure(_) => {
                                     Err(Error::new(Kind::SslHandshake(handshake_err), details))
                                 }
-                                HandshakeError::Interrupted(mid) => {
+                                HandshakeError::WouldBlock(mid) => {
                                     self.socket = Stream::tls(mid);
                                     Ok(())
                                 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -609,6 +609,9 @@ where
                             end
                         };
                         res.get_mut().truncate(end);
+                    } else {
+                        // NOTE: wait to be polled again; response not ready.
+                        return Ok(());
                     }
                 }
             }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -317,13 +317,14 @@ pub trait Handler {
             Kind::Protocol,
             format!("Unable to parse domain from {}. Needed for SSL.", url),
         ))?;
-        let connector = TlsConnector::builder().and_then(|builder| builder.build())
-            .map_err(|e| {
-                Error::new(
-                    Kind::Internal,
-                    format!("Failed to upgrade client to SSL: {}", e),
-                )
-            })?;
+
+        let connector = TlsConnector::new().map_err(|e| {
+            Error::new(
+                Kind::Internal,
+                format!("Failed to upgrade client to SSL: {}", e),
+            )
+        })?;
+
         connector.connect(domain, stream).map_err(Error::from)
     }
     /// A method for wrapping a server TcpStream with Ssl Authentication machinery

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -194,7 +194,7 @@ impl io::Read for Stream {
                             err
                         }
                         #[cfg(feature = "nativetls")]
-                        Err(HandshakeError::Interrupted(mid)) => {
+                        Err(HandshakeError::WouldBlock(mid)) => {
                             negotiating = true;
                             *tls_stream = TlsStream::Handshake {
                                 sock: mid,
@@ -264,7 +264,7 @@ impl io::Write for Stream {
                             err
                         }
                         #[cfg(feature = "nativetls")]
-                        Err(HandshakeError::Interrupted(mid)) => {
+                        Err(HandshakeError::WouldBlock(mid)) => {
                             negotiating = true;
                             *tls_stream = TlsStream::Handshake {
                                 sock: mid,


### PR DESCRIPTION
This fixes issue #239 where the ws-rs client was panicking because it was attempting to parse the upgrade response even if the read failed due to the socket not being ready.

EDIT: rebased to master