### PR TITLE
Limit maximal size of incoming fragment.

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -714,7 +714,8 @@ where
     }
 
     fn read_frames(&mut self) -> Result<()> {
-        while let Some(mut frame) = Frame::parse(&mut self.in_buffer)? {
+        let max_size = self.settings.max_fragment_size as u64;
+        while let Some(mut frame) = Frame::parse(&mut self.in_buffer, max_size)? {
             match self.state {
                 // Ignore data received after receiving close frame
                 RespondingClose | FinishedClose => continue,

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -244,7 +244,7 @@ impl Frame {
     }
 
     /// Parse the input stream into a frame.
-    pub fn parse(cursor: &mut Cursor<Vec<u8>>) -> Result<Option<Frame>> {
+    pub fn parse(cursor: &mut Cursor<Vec<u8>>, max_payload_length: u64) -> Result<Option<Frame>> {
         let size = cursor.get_ref().len() as u64 - cursor.position();
         let initial = cursor.position();
         trace!("Position in buffer {}", initial);
@@ -298,6 +298,16 @@ impl Frame {
             header_length += length_nbytes as u64;
         }
         trace!("Payload length: {}", length);
+
+        if length > max_payload_length {
+            return Err(Error::new(
+                Kind::Protocol,
+                format!(
+                    "Rejected frame with payload length exceeding defined max: {}.",
+                    max_payload_length
+                ),
+            ));
+        }
 
         let mask = if masked {
             let mut mask_bytes = [0u8; 4];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,6 +158,9 @@ pub struct Settings {
     /// The maximum length of outgoing frames. Messages longer than this will be fragmented.
     /// Default: 65,535
     pub fragment_size: usize,
+    /// The maximum length of acceptable incoming frames. Messages longer than this will be rejected.
+    /// Default: unlimited
+    pub max_fragment_size: usize,
     /// The size of the incoming buffer. A larger buffer uses more memory but will allow for fewer
     /// reallocations.
     /// Default: 2048
@@ -245,6 +248,7 @@ impl Default for Settings {
             fragments_capacity: 10,
             fragments_grow: true,
             fragment_size: u16::max_value() as usize,
+            max_fragment_size: usize::max_value(),
             in_buffer_capacity: 2048,
             in_buffer_grow: true,
             out_buffer_capacity: 2048,


### PR DESCRIPTION
Since frame size is allowed to be up to `2^64` one can forge a frame that declares extremely large payload size.

In case we haven't received enough data yet:
https://github.com/housleyjk/ws-rs/compare/master...tomusdrw:td-maxframe?expand=1#diff-8c1748e0d20c7a39978ef7656d9f39f4R326

we reset the cursor position and wait for more data in `in_buffer`.

By default the `in_buffer` is allowed to grow indefinitely, so the server will go OOM at some point trying to read such a big frame.

PR introduces additional setting `max_fragment_size` which defines maximal (sane) allowed frame payload size.