### PR TITLE
added missing ``` in factory.rs docs

### DIFF
--- a/src/factory.rs
+++ b/src/factory.rs
@@ -86,6 +86,7 @@ pub trait Factory {
     ///         }
     ///     }
     /// }
+    /// ```
     #[inline]
     fn server_connected(&mut self, ws: Sender) -> Self::Handler {
         self.connection_made(ws)


### PR DESCRIPTION
There's a missing closing ``` in factory.rs docs. Silly little thing, but bothered me enough to do this.