### PR TITLE
Limit in/out buffer growth with a Vec<u8> wrapper

### DIFF
--- a/src/capped_buffer.rs
+++ b/src/capped_buffer.rs
@@ -1,0 +1,80 @@
+use bytes::BufMut;
+use std::ops::{Deref, DerefMut};
+use std::io;
+
+pub struct CappedBuffer {
+    buf: Vec<u8>,
+    max: usize,
+}
+
+impl CappedBuffer {
+    pub fn new(mut capacity: usize, max: usize) -> Self {
+        if capacity > max {
+            capacity = max;
+        }
+
+        Self {
+            buf: Vec::with_capacity(capacity),
+            max,
+        }
+    }
+
+    #[inline]
+    pub fn remaining(&self) -> usize {
+        self.max - self.buf.len()
+    }
+}
+
+impl AsRef<[u8]> for CappedBuffer {
+    fn as_ref(&self) -> &[u8] {
+        &self.buf
+    }
+}
+
+impl AsMut<[u8]> for CappedBuffer {
+    fn as_mut(&mut self) -> &mut [u8] {
+        &mut self.buf
+    }
+}
+
+impl Deref for CappedBuffer {
+    type Target = Vec<u8>;
+
+    fn deref(&self) -> &Vec<u8> {
+        &self.buf
+    }
+}
+
+impl DerefMut for CappedBuffer {
+    fn deref_mut(&mut self) -> &mut Vec<u8> {
+        &mut self.buf
+    }
+}
+
+impl io::Write for CappedBuffer {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        if buf.len() < self.remaining_mut() {
+            self.buf.write(buf)
+        } else {
+            Err(io::Error::new(io::ErrorKind::InvalidInput, "Input exceeds buffer capacity"))
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.buf.flush()
+    }
+}
+
+impl BufMut for CappedBuffer {
+    fn remaining_mut(&self) -> usize {
+        self.remaining()
+    }
+
+    unsafe fn advance_mut(&mut self, cnt: usize) {
+        self.buf.advance_mut(cnt);
+    }
+
+    unsafe fn bytes_mut(&mut self) -> &mut [u8] {
+        self.buf.bytes_mut()
+    }
+}

--- a/src/capped_buffer.rs
+++ b/src/capped_buffer.rs
@@ -30,7 +30,7 @@ impl CappedBuffer {
     /// effectively forgetting the shifted out bytes.
     /// New length of the buffer will be adjusted accordingly.
     pub fn shift(&mut self, shift: usize) {
-        if shift > self.buf.len() {
+        if shift >= self.buf.len() {
             self.buf.clear();
             return;
         }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1177,9 +1177,7 @@ where
         trace!("Buffering frame to {}:\n{}", self.peer_addr(), frame);
 
         let pos = self.out_buffer.position();
-        self.out_buffer.seek(SeekFrom::End(0))?;
-        frame.format(self.out_buffer.get_mut())?; // TODO: make sure nothing breaks
-        self.out_buffer.seek(SeekFrom::Start(pos))?;
+        frame.format(self.out_buffer.get_mut())?;
         Ok(())
     }
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1186,7 +1186,7 @@ where
             if self.out_buffer.position() == 0 {
                 return Err(Error::new(
                     Kind::Capacity,
-                    "Maxed out output buffer for connection.",
+                    "Reached the limit of the output buffer for the connection.",
                 ));
             }
 
@@ -1207,7 +1207,7 @@ where
                 if self.in_buffer.position() == 0 {
                     return Err(Error::new(
                         Kind::Capacity,
-                        "Maxed out input buffer for connection.",
+                        "Reached the limit of the input buffer for the connection.",
                     ));
                 }
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,6 +1,6 @@
 use std::borrow::Borrow;
 use std::collections::VecDeque;
-use std::io::{Cursor, Read, Seek, SeekFrom, Write};
+use std::io::{Cursor, Read, Write};
 use std::mem::replace;
 use std::net::SocketAddr;
 use std::str::from_utf8;
@@ -427,8 +427,8 @@ where
                         self.handler.on_error(err);
                         if let Err(err) = self.send_close(CloseCode::Size, reason) {
                             self.handler.on_error(err);
-                            self.disconnect()
                         }
+                        self.disconnect()
                     }
                     Kind::Protocol => {
                         if self.settings.panic_on_protocol {
@@ -1176,7 +1176,6 @@ where
 
         trace!("Buffering frame to {}:\n{}", self.peer_addr(), frame);
 
-        let pos = self.out_buffer.position();
         frame.format(self.out_buffer.get_mut())?;
         Ok(())
     }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1194,9 +1194,9 @@ where
             }
 
             // Shift the buffer
-            let mut new = CappedBuffer::new(self.out_buffer.get_ref().capacity(), self.settings.max_out_buffer_capacity);
-            new.write_all(&self.out_buffer.get_ref()[self.out_buffer.position() as usize..])?;
-            self.out_buffer = Cursor::new(new);
+            let prev_pos = self.out_buffer.position() as usize;
+            self.out_buffer.set_position(0);
+            self.out_buffer.get_mut().shift(prev_pos);
         }
         Ok(())
     }
@@ -1215,9 +1215,9 @@ where
                 }
 
                 // Shift the buffer
-                let mut new = CappedBuffer::new(self.in_buffer.get_ref().capacity(), self.settings.max_in_buffer_capacity);
-                new.write_all(&self.in_buffer.get_ref()[self.in_buffer.position() as usize..])?;
-                self.in_buffer = Cursor::new(new);
+                let prev_pos = self.in_buffer.position() as usize;
+                self.in_buffer.set_position(0);
+                self.in_buffer.get_mut().shift(prev_pos);
             }
             Ok(Some(len))
         } else {

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -5,6 +5,7 @@ use std::io::{Cursor, ErrorKind, Read, Write};
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use rand;
 
+use capped_buffer::CappedBuffer;
 use protocol::{CloseCode, OpCode};
 use result::{Error, Kind, Result};
 use stream::TryReadBuf;
@@ -244,7 +245,7 @@ impl Frame {
     }
 
     /// Parse the input stream into a frame.
-    pub fn parse(cursor: &mut Cursor<Vec<u8>>, max_payload_length: u64) -> Result<Option<Frame>> {
+    pub fn parse(cursor: &mut Cursor<CappedBuffer>, max_payload_length: u64) -> Result<Option<Frame>> {
         let size = cursor.get_ref().len() as u64 - cursor.position();
         let initial = cursor.position();
         trace!("Position in buffer {}", initial);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ extern crate url;
 #[macro_use]
 extern crate log;
 
+mod capped_buffer;
 mod communication;
 mod connection;
 mod factory;
@@ -169,6 +170,9 @@ pub struct Settings {
     /// false, a Capacity error will be triggered instead.
     /// Default: true
     pub in_buffer_grow: bool,
+    /// The maximum size of the incoming buffer, if `in_buffer_grow` is enabled.
+    /// Default: unlimited
+    pub max_in_buffer_capacity: usize,
     /// The size of the outgoing buffer. A larger buffer uses more memory but will allow for fewer
     /// reallocations.
     /// Default: 2048
@@ -177,6 +181,9 @@ pub struct Settings {
     /// false, a Capacity error will be triggered instead.
     /// Default: true
     pub out_buffer_grow: bool,
+    /// The maximum size of the outgoing buffer, if `out_buffer_grow` is enabled.
+    /// Default: unlimited
+    pub max_out_buffer_capacity: usize,
     /// Whether to panic when an Internal error is encountered. Internal errors should generally
     /// not occur, so this setting defaults to true as a debug measure, whereas production
     /// applications should consider setting it to false.
@@ -251,8 +258,10 @@ impl Default for Settings {
             max_fragment_size: usize::max_value(),
             in_buffer_capacity: 2048,
             in_buffer_grow: true,
+            max_in_buffer_capacity: usize::max_value(),
             out_buffer_capacity: 2048,
             out_buffer_grow: true,
+            max_out_buffer_capacity: usize::max_value(),
             panic_on_internal: true,
             panic_on_capacity: false,
             panic_on_protocol: false,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,26 +162,18 @@ pub struct Settings {
     /// The maximum length of acceptable incoming frames. Messages longer than this will be rejected.
     /// Default: unlimited
     pub max_fragment_size: usize,
-    /// The size of the incoming buffer. A larger buffer uses more memory but will allow for fewer
-    /// reallocations.
+    /// The initial size of the incoming buffer. A larger buffer uses more memory but will allow for
+    /// fewer reallocations.
     /// Default: 2048
     pub in_buffer_capacity: usize,
-    /// Whether to reallocate the incoming buffer when `in_buffer_capacity` is reached. If this is
-    /// false, a Capacity error will be triggered instead.
-    /// Default: true
-    pub in_buffer_grow: bool,
-    /// The maximum size of the incoming buffer, if `in_buffer_grow` is enabled.
+    /// The maximum size to which the incoming buffer can grow.
     /// Default: unlimited
     pub max_in_buffer_capacity: usize,
-    /// The size of the outgoing buffer. A larger buffer uses more memory but will allow for fewer
-    /// reallocations.
+    /// The initial size of the outgoing buffer. A larger buffer uses more memory but will allow for
+    /// fewer reallocations.
     /// Default: 2048
     pub out_buffer_capacity: usize,
-    /// Whether to reallocate the incoming buffer when `out_buffer_capacity` is reached. If this is
-    /// false, a Capacity error will be triggered instead.
-    /// Default: true
-    pub out_buffer_grow: bool,
-    /// The maximum size of the outgoing buffer, if `out_buffer_grow` is enabled.
+    /// The maximum size to which the outgoing buffer can grow.
     /// Default: unlimited
     pub max_out_buffer_capacity: usize,
     /// Whether to panic when an Internal error is encountered. Internal errors should generally
@@ -257,10 +249,8 @@ impl Default for Settings {
             fragment_size: u16::max_value() as usize,
             max_fragment_size: usize::max_value(),
             in_buffer_capacity: 2048,
-            in_buffer_grow: true,
             max_in_buffer_capacity: usize::max_value(),
             out_buffer_capacity: 2048,
-            out_buffer_grow: true,
             max_out_buffer_capacity: usize::max_value(),
             panic_on_internal: true,
             panic_on_capacity: false,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,14 +167,14 @@ pub struct Settings {
     /// Default: 2048
     pub in_buffer_capacity: usize,
     /// The maximum size to which the incoming buffer can grow.
-    /// Default: unlimited
+    /// Default: 10,485,760
     pub max_in_buffer_capacity: usize,
     /// The initial size of the outgoing buffer. A larger buffer uses more memory but will allow for
     /// fewer reallocations.
     /// Default: 2048
     pub out_buffer_capacity: usize,
     /// The maximum size to which the outgoing buffer can grow.
-    /// Default: unlimited
+    /// Default: 10,485,760
     pub max_out_buffer_capacity: usize,
     /// Whether to panic when an Internal error is encountered. Internal errors should generally
     /// not occur, so this setting defaults to true as a debug measure, whereas production
@@ -249,9 +249,9 @@ impl Default for Settings {
             fragment_size: u16::max_value() as usize,
             max_fragment_size: usize::max_value(),
             in_buffer_capacity: 2048,
-            max_in_buffer_capacity: usize::max_value(),
+            max_in_buffer_capacity: 10 * 1024 * 1024,
             out_buffer_capacity: 2048,
-            max_out_buffer_capacity: usize::max_value(),
+            max_out_buffer_capacity: 10 * 1024 * 1024,
             panic_on_internal: true,
             panic_on_capacity: false,
             panic_on_protocol: false,

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -41,10 +41,6 @@ pub trait TryReadBuf: io::Read {
         let res = map_non_block(self.read(unsafe { buf.bytes_mut() }));
 
         if let Ok(Some(cnt)) = res {
-            if cnt > buf.remaining_mut() {
-                return Err(io::Error::new(io::ErrorKind::InvalidInput, "Exceeded buffer limit"));
-            }
-
             unsafe {
                 buf.advance_mut(cnt);
             }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -41,6 +41,10 @@ pub trait TryReadBuf: io::Read {
         let res = map_non_block(self.read(unsafe { buf.bytes_mut() }));
 
         if let Ok(Some(cnt)) = res {
+            if cnt > buf.remaining_mut() {
+                return Err(io::Error::new(io::ErrorKind::InvalidInput, "Exceeded buffer limit"));
+            }
+
             unsafe {
                 buf.advance_mut(cnt);
             }


### PR DESCRIPTION
This PR introduces a `CappedBuffer` wrapper around a `Vec<u8>` which effectively enforces buffer capacity limits. Exceeding capacity limits will force a disconnect.

There are changes to the settings involved, so this is a breaking change.