### PR TITLE
Don't panic when trying to close a connection in "Connecting" state 

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1134,7 +1134,7 @@ where
             // We are initiating a closing handshake.
             Open => self.state = AwaitingClose,
             Connecting(_, _) => {
-                debug_assert!(false, "Attempted to close connection while not yet open.")
+                error!("Attempted to close connection while not yet open.")
             }
         }
 


### PR DESCRIPTION
It's almost impossible to control the state of a `WebSocket` if there's a panic here (e.g. being able to start/stop a ws client or server).

We must control each connection state to decide how to close a connection to avoid this panic, and most important point, to shutdown the `WebSocket`.   
`ws::Sender::shutdown` should never panic, because it's the only way to stop a running `WebSocket`, and we should not have to care about the state of connections.

It's not happening in release mode, but using this crate in tests seems to be a valid use-case.

Why not using an error log instead?



