### PR TITLE
Fix panic when using permessage-deflate

### DIFF
--- a/src/deflate/context.rs
+++ b/src/deflate/context.rs
@@ -67,7 +67,7 @@ impl Compressor {
         debug_assert!(window_bits <= 15, "Received too large window size.");
 
         unsafe {
-            let mut stream: Box<ffi::z_stream> = Box::new(mem::zeroed());
+            let mut stream: Box<ffi::z_stream> = Box::new(MaybeUninit::uninit().assume_init());
             let result = ffi::deflateInit2_(
                 stream.as_mut(),
                 9,
@@ -139,7 +139,7 @@ impl Decompressor {
         debug_assert!(window_bits <= 15, "Received too large window size.");
 
         unsafe {
-            let mut stream: Box<ffi::z_stream> = Box::new(mem::zeroed());
+            let mut stream: Box<ffi::z_stream> = Box::new(MaybeUninit::uninit().assume_init());
             let result = ffi::inflateInit2_(
                 stream.as_mut(),
                 -window_bits as c_int,

--- a/src/deflate/context.rs
+++ b/src/deflate/context.rs
@@ -1,5 +1,6 @@
 use std::mem;
 use std::slice;
+use std::mem::MaybeUninit;
 
 use super::ffi;
 use super::libc::{c_char, c_int, c_uint};


### PR DESCRIPTION
When using the `permessage-deflate` feature under rustc v1.59.0, I was getting a panic because function pointers cannot be zeroed: "attempted to zero-initialize type `libz_sys::z_stream`, which is invalid"

This PR fixes the issue by using uninitialized memory, which should be slightly more performant anyways.